### PR TITLE
ClpEventHandler in ClpModel: fix such that custom child class can be passed to model

### DIFF
--- a/Clp/src/ClpModel.hpp
+++ b/Clp/src/ClpModel.hpp
@@ -882,7 +882,7 @@ public:
           return defaultHandler_;
      }
      /// Pass in Event handler (cloned and deleted at end)
-     void passInEventHandler(const ClpEventHandler * eventHandler);
+     void passInEventHandler(ClpEventHandler * eventHandler);
      /// Event handler
      inline ClpEventHandler * eventHandler() const {
           return eventHandler_;
@@ -1229,6 +1229,8 @@ protected:
      CoinMessageHandler * handler_;
      /// Flag to say if default handler (so delete)
      bool defaultHandler_;
+     /// Flag to say if default event handler (so delete)
+     bool defaultEventHandler_;
      /// Thread specific random number generator
      CoinThreadRandom randomNumberGenerator_;
      /// Event handler

--- a/Clp/src/ClpSimplex.cpp
+++ b/Clp/src/ClpSimplex.cpp
@@ -7085,10 +7085,7 @@ ClpSimplex::restoreModel(const char * fileName)
      FILE * fp = fopen(fileName, "rb");
      if (fp) {
           // Get rid of current model
-          // save event handler in case already set
-          ClpEventHandler * handler = eventHandler_->clone();
           ClpModel::gutsOfDelete(0);
-          eventHandler_ = handler;
           gutsOfDelete(0);
           int i;
           for (i = 0; i < 6; i++) {
@@ -9797,10 +9794,11 @@ ClpSimplex::originalModel(ClpSimplex * miniModel)
 }
 // Pass in Event handler (cloned and deleted at end)
 void
-ClpSimplex::passInEventHandler(const ClpEventHandler * eventHandler)
+ClpSimplex::passInEventHandler(ClpEventHandler * eventHandler)
 {
      delete eventHandler_;
-     eventHandler_ = eventHandler->clone();
+     eventHandler_ = eventHandler;
+     defaultEventHandler_ = false;
      eventHandler_->setSimplex(this);
 }
 #ifndef NDEBUG

--- a/Clp/src/ClpSimplex.hpp
+++ b/Clp/src/ClpSimplex.hpp
@@ -281,7 +281,7 @@ public:
      void borrowModel(ClpModel & otherModel);
      void borrowModel(ClpSimplex & otherModel);
      /// Pass in Event handler (cloned and deleted at end)
-     void passInEventHandler(const ClpEventHandler * eventHandler);
+     void passInEventHandler(ClpEventHandler * eventHandler);
      /// Puts solution back into small model
      void getbackSolution(const ClpSimplex & smallModel, const int * whichRow, const int * whichColumn);
      /** Load nonlinear part of problem from AMPL info


### PR DESCRIPTION
I had an issue with making a custom child class of ClpEventHandler and hading it over to the model class with the PassIn function. I fixed it in the same manner as the message handler is used. I already used the fix and it worked so far.